### PR TITLE
#159101123 Update Coveralls CI badge in ReadMe in order to get it updated in the Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/chinemelu/BC_34-myDiary.svg?branch=develop)](https://travis-ci.org/chinemelu/BC_34-myDiary)[![Coverage Status](https://coveralls.io/repos/github/chinemelu/BC_34-myDiary/badge.svg?branch=develop)](https://coveralls.io/github/chinemelu/BC_34-myDiary?branch=develop)
+[![Build Status](https://travis-ci.org/chinemelu/BC_34-myDiary.svg?branch=develop)](https://travis-ci.org/chinemelu/BC_34-myDiary)[![Coverage Status](https://coveralls.io/repos/github/chinemelu/BC_34-myDiary/badge.svg?branch=develop)](https://coveralls.io/github/chinemelu/BC_34-myDiary?branch=develop&service=github)
 [![Maintainability](https://api.codeclimate.com/v1/badges/37e7f8cade3573f23a57/maintainability)](https://codeclimate.com/github/chinemelu/BC_34-myDiary/maintainability)
 
 # BC_34-myDiary


### PR DESCRIPTION
#### What does this PR do?
update Coveralls CI badge in ReadMe in order to get it updated regularly

#### Description of Task to be completed?
Alter badge in ReadMe and add `service=github` in its URL

#### Any background context you want to provide?
After the initial addition of badges, badge keep displaying 'unknown', even though test coverage should be 99.23%

#### What are the relevant pivotal tracker stories?
#159101123
